### PR TITLE
Clarify permission error

### DIFF
--- a/src/changelog.md
+++ b/src/changelog.md
@@ -64,3 +64,13 @@ This change isolates the unpredictable AI from the strict requirements of format
     *   The complex and unreliable `verificationPrompt` and `fixMCQFormatting` functions will be **removed**, as they are now obsolete.
 
 This architectural improvement ensures that the `explanation` is always present and correctly formatted, and allows us to focus the AI's power on making its *content* world-class.
+
+### Ticket-002: Clarify Firestore Permission Error
+- **Status**: Done
+- **Date**: 2024-07-26
+
+#### Affected Files
+1. `src/services/historyService.ts`
+
+#### Change
+- Updated permission-denied error message in `getAllHistory` to note missing read access and mention Firestore may show a link for creating an index when using orderBy.

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -68,8 +68,7 @@ async function getAllHistory(userId: string): Promise<HistoryEntry[]> {
   } catch(error) {
       console.error("Error fetching all history: ", error);
       if ((error as any).code === 'permission-denied') {
-          // This error message now points to a potential index issue that the user might have to create if Firestore prompts them.
-          throw new Error("Could not read history due to a permission error. This usually happens when a Firestore index is missing. Please check your browser's developer console for a link to create the required index.");
+          throw new Error("Could not read history. Missing read permission is likely the cause. If the query ever uses orderBy, Firestore may show a link to create an index.");
       }
       throw error;
   }


### PR DESCRIPTION
## Summary
- make Firestore read permission message clearer
- log update in changelog

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686b9c53063c8322afcdc9018f968b19