### PR TITLE
Add initial Jest tests

### DIFF
--- a/first_test.md
+++ b/first_test.md
@@ -1,0 +1,27 @@
+# Test Execution Summary
+
+All tests were executed on the dedicated testing branch. The following unit tests were added:
+
+- `Card` component rendering
+- `LeftSidebar` navigation links
+- `getUserUsage` service function
+
+Jest was configured with `ts-jest` using a dedicated `tsconfig.jest.json` to properly handle JSX. After installing dependencies, `npm test` reported all suites passing.
+
+## Results
+
+```
+PASS src/components/ui/card.test.tsx
+PASS src/components/ui/button.test.tsx
+PASS src/services/usageService.test.ts
+PASS src/app/dashboard/components/layout/LeftSidebar.test.tsx
+```
+
+Linting and type checking reveal existing issues unrelated to the new tests. They remain to be addressed separately.
+
+## Suggestions
+
+- Integrate CI to run `npm test`, `npm run lint`, and `npm run typecheck` on pull requests.
+- Gradually increase coverage by adding tests for remaining components and services.
+
+All testing was performed on this branch before merging to `master`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  preset: 'ts-jest/presets/js-with-ts',
+  preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
   moduleNameMapper: {
@@ -12,7 +12,7 @@ module.exports = {
     '!src/**/index.ts',
   ],
   transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: false }],
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.jest.json', diagnostics: false }],
   },
   coverageThreshold: {
     global: {

--- a/src/app/dashboard/components/layout/LeftSidebar.test.tsx
+++ b/src/app/dashboard/components/layout/LeftSidebar.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import LeftSidebar from './LeftSidebar';
+
+jest.mock('lucide-react', () => {
+  const Icon = () => <svg />;
+  return {
+    BarChart3: Icon,
+    Newspaper: Icon,
+    Mic: Icon,
+    FileQuestion: Icon,
+    PenLine: Icon,
+    Book: Icon,
+    Users: Icon,
+    HelpCircle: Icon,
+    LogOut: Icon,
+    LayoutDashboard: Icon,
+    FileText: Icon,
+    UserRound: Icon,
+    CalendarDays: Icon,
+    BookOpen: Icon,
+    GraduationCap: Icon,
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard'
+}));
+
+describe('LeftSidebar', () => {
+  it('renders navigation links', () => {
+    render(<LeftSidebar usageStats={null} />);
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Newspaper Analysis')).toBeInTheDocument();
+    expect(screen.getByText('Mock Interview')).toBeInTheDocument();
+    expect(screen.getByText('Question Bank')).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/card.test.tsx
+++ b/src/components/ui/card.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { Card, CardHeader, CardTitle, CardContent } from './card';
+
+describe('Card Components', () => {
+  it('renders card structure correctly', () => {
+    render(
+      <Card data-testid="test-card">
+        <CardHeader>
+          <CardTitle>Test Title</CardTitle>
+        </CardHeader>
+        <CardContent>Test Content</CardContent>
+      </Card>
+    );
+
+    expect(screen.getByTestId('test-card')).toBeInTheDocument();
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+});

--- a/src/services/usageService.test.ts
+++ b/src/services/usageService.test.ts
@@ -1,0 +1,19 @@
+import { getUserUsage } from './usageService';
+import { doc, getDoc } from 'firebase/firestore';
+
+jest.mock('@/lib/firebase', () => ({ db: {} }));
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  getDoc: jest.fn()
+}));
+
+describe('Usage Service', () => {
+  it('gets user usage statistics', async () => {
+    (doc as jest.Mock).mockReturnValue('docRef');
+    (getDoc as jest.Mock).mockResolvedValue({ exists: () => true, data: () => ({ totalAnalyses: 5 }) });
+
+    const result = await getUserUsage('user1');
+    expect(result).toEqual({ totalAnalyses: 5 });
+    expect(doc).toHaveBeenCalledWith({}, 'toolUsage', 'user1');
+  });
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest
- add sample unit tests for Card component, LeftSidebar, and Usage service
- document test execution results

## Testing
- `npm test --silent`
- `npm run lint` *(fails: various lint errors)*
- `npm run typecheck` *(fails: TypeScript errors)*


------
https://chatgpt.com/codex/tasks/task_e_6870193cc20c8322ae7ab2fb66263a50