### PR TITLE
Clean up test documentation

### DIFF
--- a/src/changelog.md
+++ b/src/changelog.md
@@ -90,3 +90,47 @@ Introduce a minimal Jest setup with one component test and a GitHub Actions work
 - Added a CI workflow that installs dependencies and runs `npm run lint`, `npm run typecheck`, and `npm test`.
 - Created Jest configuration with coverage thresholds and a setup file.
 - Added a simple button component test and a `test` npm script.
+
+### Ticket-003: Clean up test documentation
+- **Status**: Completed
+- **Date**: 2025-07-10
+
+#### Problem Statement
+
+The `test.md` file contained stray text at the beginning and an unfinished code block at the end.
+
+#### Proposed Solution
+
+Remove the extraneous first line and closing backticks to restore valid markdown.
+
+#### Affected Files
+
+1. `test.md`
+
+#### Implementation Details
+
+- Deleted the placeholder line `test` at the top of the file.
+- Removed the leftover code fence at the end of the document.
+
+### Ticket-004: HTML summary for failing tests
+- **Status**: Completed
+- **Date**: 2025-07-10
+
+#### Problem Statement
+
+The project lacked an easy way to review the results of running `npm run lint`, `npm run typecheck`, and `npm test`.
+
+#### Proposed Solution
+
+Generate these commands and capture their output in a simple HTML file for quick viewing.
+
+#### Affected Files
+
+1. `test-results.html`
+2. `src/changelog.md`
+
+#### Implementation Details
+
+- Installed dependencies to run the commands.
+- Executed the lint, typecheck, and test scripts, saving output to `/tmp` logs.
+- Created `test-results.html` to display the tail of these logs for reference.

--- a/test-results.html
+++ b/test-results.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Test Summary</title>
+</head>
+<body>
+  <h1>Test Results Summary</h1>
+  <h2>npm run lint</h2>
+  <pre>
+./src/services/writingEvaluationService.ts
+279:22  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+280:24  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+281:23  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+./src/types/quiz.ts
+23:20  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+47:20  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
+  </pre>
+  <h2>npm run typecheck</h2>
+  <pre>
+      Type 'DragEventHandler<HTMLDivElement>' is not assignable to type '(event: MouseEvent | PointerEvent | TouchEvent, info: PanInfo) => void'.
+        Types of parameters 'event' and 'event' are incompatible.
+          Type 'MouseEvent | PointerEvent | TouchEvent' is not assignable to type 'DragEvent<HTMLDivElement>'.
+            Type 'MouseEvent' is missing the following properties from type 'DragEvent<HTMLDivElement>': dataTransfer, nativeEvent, isDefaultPrevented, isPropagationStopped, persist
+src/lib/analytics.ts(106,7): error TS2322: Type 'string | null' is not assignable to type 'string | undefined'.
+  Type 'null' is not assignable to type 'string | undefined'.
+src/lib/analytics.ts(415,3): error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.
+src/lib/analytics.ts(445,39): error TS2339: Property 'onFID' does not exist on type 'typeof import("/workspace/studio_prep/node_modules/web-vitals/dist/modules/index")'.
+src/services/ocrService.ts(168,32): error TS7016: Could not find a declaration file for module 'pdf-parse'. '/workspace/studio_prep/node_modules/pdf-parse/index.js' implicitly has an 'any' type.
+  Try `npm i --save-dev @types/pdf-parse` if it exists or add a new declaration (.d.ts) file containing `declare module 'pdf-parse';`
+  </pre>
+  <h2>npm test</h2>
+  <pre>
+    You'll find more details and examples of these config options in the docs:
+    https://jestjs.io/docs/configuration
+    For information about custom transformations, see:
+    https://jestjs.io/docs/code-transformation
+
+    Details:
+
+    /workspace/studio_prep/src/components/ui/button.test.tsx:7
+            (0, react_1.render)(<button_1.Button>Click me</button_1.Button>);
+                                ^
+
+    SyntaxError: Unexpected token '<'
+
+      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1505:14)
+
+Test Suites: 1 failed, 1 total
+Tests:       0 total
+Snapshots:   0 total
+Time:        1.366 s
+Ran all test suites.
+  </pre>
+</body>
+</html>

--- a/test.md
+++ b/test.md
@@ -1,5 +1,3 @@
-test
-
 # Comprehensive Test Documentation - PrepTalk Platform
 
 ## Table of Contents
@@ -939,4 +937,3 @@ test.describe('Newspaper Analysis Flow', () => {
     await expect(page.locator('[data-testid="history-item"]').first()).toBeVisible();
   });
 });
-```


### PR DESCRIPTION
## Summary
- clean up extraneous lines in `test.md`
- document the change in `src/changelog.md`
- run lint, typecheck, and test commands and save their output in `test-results.html`

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run typecheck` *(fails: Object literal may only specify known properties, etc.)*
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68701a8f15608322bfb4670441bb8f98